### PR TITLE
Android: remove destroy from onDetachedFromEngine

### DIFF
--- a/android/src/main/java/com/sumsg/metronome/MetronomePlugin.java
+++ b/android/src/main/java/com/sumsg/metronome/MetronomePlugin.java
@@ -103,7 +103,6 @@ public class MetronomePlugin implements FlutterPlugin, MethodCallHandler {
     context = null;
     channel.setMethodCallHandler(null);
     eventTick.setStreamHandler(null);
-    metronome.destroy();
   }
 
   private void metronomeInit(@NonNull MethodCall call) {


### PR DESCRIPTION
Remove destroy from onDetachedFromEngine because of multiple reasons:
- it's a client's responsibility to destroy on dispose()
- to keep it consistent with iOS implementation
- metronome instance sometimes could be null