### PR TITLE
Fix 1-beat offset in Android for tick callback

### DIFF
--- a/android/src/main/java/com/sumsg/metronome/Metronome.java
+++ b/android/src/main/java/com/sumsg/metronome/Metronome.java
@@ -68,6 +68,10 @@ public class Metronome {
         if (!isPlaying()) {
             updated = true;
             onTick();
+            // Send immediate tick event to match iOS behavior
+            if (eventTickSink != null) {
+                eventTickSink.success(0);  // Send tick 0 immediately
+            }
             audioTrack.play();
             startMetronome();
         }


### PR DESCRIPTION
## Issue

The original Android implementation has a timing discrepancy compared to iOS:
- **Android**: Metronome plays audio immediately when `play()` is called, but the first tick callback comes later
- **iOS**: Metronome waits for the first tick before playing, so audio and tick events are synchronized

This causes a 1-beat offset on Android where the visual beat display doesn't match the audio timing.

## Fix

**File**: `android/src/main/java/com/sumsg/metronome/Metronome.java`

**Change**: Added immediate tick callback in the `play()` method (lines 71-74):

```java
public void play() {
    if (!isPlaying()) {
        updated = true;
        onTick();
        // Send immediate tick event to match iOS behavior
        if (eventTickSink != null) {
            eventTickSink.success(0);  // Send tick 0 immediately
        }
        audioTrack.play();
        startMetronome();
    }
}
```

## Result

- ✅ Android now sends tick 0 immediately when audio starts playing
- ✅ Both platforms have synchronized audio and tick events
- ✅ Beat display aligns with audio timing from the first beat