### PR TITLE
Fix crash when disconnecting player node after engine reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ example/windows/.vs/
 .vs/
 .metadata
 darwin/metronome/.swiftpm/*
+darwin/metronome/.build/

--- a/darwin/metronome/Sources/metronome/Metronome.swift
+++ b/darwin/metronome/Sources/metronome/Metronome.swift
@@ -67,7 +67,9 @@ class Metronome {
 #endif
     }
     private func reconnectPlayerNode() {
-        audioEngine.disconnectNodeOutput(audioPlayerNode)
+        if !audioEngine.outputConnectionPoints(for: audioPlayerNode, outputBus: 0).isEmpty {
+            audioEngine.disconnectNodeOutput(audioPlayerNode)
+        }
         audioEngine.connect(audioPlayerNode, to: mixerNode, format: audioFileMain.processingFormat)
     }
 

--- a/darwin/metronome/Sources/metronome/Metronome.swift
+++ b/darwin/metronome/Sources/metronome/Metronome.swift
@@ -193,7 +193,9 @@ class Metronome {
             self.audioEngine.stop()
             self.audioEngine.reset()
 
-            self.reconnectPlayerNode()
+            // reset() clears all connections, so connect directly without disconnecting first.
+            // Calling outputConnectionPointsForNode after reset() throws an NSException.
+            self.audioEngine.connect(self.audioPlayerNode, to: self.mixerNode, format: self.audioFileMain.processingFormat)
 
             do {
                 try self.audioEngine.start()

--- a/darwin/metronome/Sources/metronome/Metronome.swift
+++ b/darwin/metronome/Sources/metronome/Metronome.swift
@@ -187,15 +187,9 @@ class Metronome {
         if wasPlaying {
             self.stop()
         }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.audioPlayerNode.stop()
-            self.audioEngine.stop()
-            self.audioEngine.reset()
 
-            // reset() clears all connections, so connect directly without disconnecting first.
-            // Calling outputConnectionPointsForNode after reset() throws an NSException.
-            self.audioEngine.connect(self.audioPlayerNode, to: self.mixerNode, format: self.audioFileMain.processingFormat)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.audioEngine.stop()
 
             do {
                 try self.audioEngine.start()

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -139,33 +139,33 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   metronome:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "2.0.6"
+    version: "2.0.7"
   path:
     dependency: transitive
     description:
@@ -255,10 +255,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -292,5 +292,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
AVAudioEngine.disconnectNodeOutput throws an NSException if the node has no output connections. After audioEngine.reset() in handleRouteChange all connections are already cleared, so the subsequent disconnectNodeOutput call in reconnectPlayerNode crashes. Guard the call by checking outputConnectionPoints first.